### PR TITLE
chore(metrics): change and add some metrics attributes

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -18,7 +18,7 @@ jobs:
           # Options
           user: itsmrnatural
           template: classic
-          base: header, activity, community, repositories, metadata
+          base: header, metadata
           config_timezone: UTC
           
           # Display achievements
@@ -45,5 +45,5 @@ jobs:
           # Code Snippet
           plugin_code: yes
           plugin_code_days: 0
-          plugin_code_lines: 7
+          plugin_code_lines: 7z
           

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -23,8 +23,9 @@ jobs:
           
           # Display achievements
           plugin_achievements: yes
-          plugin_achievements_display: detailed
-          plugin_achievements_threshold: C
+          plugin_achievements_display: compact
+          plugin_achievements_threshold: B
+          plugin_achievements_secrets: true
           
           # Add programming languages statistics
           plugin_languages: yes

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -41,3 +41,9 @@ jobs:
           plugin_activity_limit: 5
           plugin_activity_visibility: public
           plugin_activity_filter: issue, pr, release, fork, review, ref/create
+
+          # Code Snippet
+          plugin_code: yes
+          plugin_code_days: 0
+          plugin_code_lines: 7
+          

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -34,11 +34,3 @@ jobs:
           plugin_languages_colors: github
           plugin_languages_threshold: 5%
           plugin_languages_limit: 8
-          
-          # Add Anilist plugin for anime statistics - only current watches
-          plugin_anilist: yes
-          plugin_anilist_user: itsmrnatural
-          plugin_anilist_medias: anime, manga
-          plugin_anilist_sections: watching, reading  # Only show currently watching/reading
-          plugin_anilist_limit: 4  # Show up to 4 items per section
-          plugin_anilist_shuffle: yes  # Randomly select entries if you have more than the limit

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -45,5 +45,12 @@ jobs:
           # Code Snippet
           plugin_code: yes
           plugin_code_days: 0
-          plugin_code_lines: 7z
-          
+          plugin_code_lines: 7
+
+          # Music Metric
+          plugin_music_token: ${{ secrets.LASTFM_KEY }}
+          plugin_music: yes
+          plugin_music_provider: lastfm
+          plugin_music_user: itsmrnatural
+          plugin_music_mode: top
+          plugin_music_limit: 4

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -29,7 +29,10 @@ jobs:
           # Add programming languages statistics
           plugin_languages: yes
           plugin_languages_categories: markup, programming
+          plugin_languages_details: bytes-size, percentage
+          plugin_languages_sections: recently-used
           plugin_languages_colors: github
+          plugin_languages_threshold: 5%
           plugin_languages_limit: 8
           
           # Add Anilist plugin for anime statistics - only current watches

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -35,3 +35,9 @@ jobs:
           plugin_languages_colors: github
           plugin_languages_threshold: 5%
           plugin_languages_limit: 8
+
+          # Recent Activities
+          plugin_activity: yes
+          plugin_activity_limit: 5
+          plugin_activity_visibility: public
+          plugin_activity_filter: issue, pr, release, fork, review, ref/create


### PR DESCRIPTION
This pull request includes significant updates to the `.github/workflows/metrics.yml` file, focusing on changing the configuration of various plugins and metrics.

### Plugin Configuration Changes:

* **Achievements Plugin**:
  * Changed display mode from `detailed` to `compact`.
  * Updated threshold from `C` to `B` and enabled secrets.

* **Programming Languages Plugin**:
  * Added details for `bytes-size` and `percentage`.
  * Included a section for `recently-used` languages.
  * Set a threshold of `5%` and limited to `8` languages.

* **Activity Plugin**:
  * Introduced a new plugin to display recent activities with a limit of `5` and visibility set to `public`.
  * Filtered activities to include issues, pull requests, releases, forks, reviews, and references/creations.

* **Code Snippet Plugin**:
  * Added a new plugin to display code snippets with a configuration of `0` days and `7` lines.

* **Music Metric Plugin**:
  * Introduced a top tracks of last 4 weeks metric using last.fm